### PR TITLE
fix: remove dlx from pnpm commands to avoid isolated env issues

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,8 +122,8 @@ export type PreferencesType = InstanceType<typeof Preferences>;
 export const pmExecuteMap: Record<PackageManager, string> = {
 	npm: "npx",
 	bun: "bun x",
-	yarn: "yarn dlx",
-	pnpm: "pnpm dlx",
+	yarn: "yarn",
+	pnpm: "pnpm",
 };
 
 export const pmRunMap: Record<PackageManager, string> = {


### PR DESCRIPTION
Using pnpm dlx runs commands in a temporary environment that can’t access local packages like drizzle-orm. This causes errors such as:

`Error please install required packages: 'drizzle-orm'`

This change runs pnpm directly to fix dependency resolution and prevent this error.